### PR TITLE
feat: App discovery with icons + settings dialog

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3020,6 +3020,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3501,7 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "uuid",
  "windows 0.58.0",
@@ -3794,6 +3819,46 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,12 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,9 +267,9 @@ fn discover_apps_in_dir(dir: &std::path::Path, apps: &mut Vec<DiscoveredApp>) {
             let path = entry.path();
 
             // Check if it's a shortcut (.lnk) file
-            if path.extension().map_or(false, |ext| ext == "lnk") {
+            if path.extension().is_some_and(|ext| ext == "lnk") {
                 if let Ok(target) = resolve_shortcut(&path) {
-                    if target.extension().map_or(false, |ext| ext == "exe") {
+                    if target.extension().is_some_and(|ext| ext == "exe") {
                         let name = path
                             .file_stem()
                             .and_then(|s| s.to_str())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,14 @@ pub struct Space {
     pub updated_at: String,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredApp {
+    pub name: String,
+    pub path: String,
+    pub icon_base64: Option<String>,
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // App state – in-memory spaces protected by a Mutex, plus the path to persist
 // ──────────────────────────────────────────────────────────────────────────────
@@ -160,6 +168,144 @@ fn delete_space(state: State<SpacesState>, id: String) -> Result<(), String> {
         return Err(format!("Space '{}' not found", id));
     }
     state.persist(&spaces)
+}
+
+#[tauri::command]
+fn discover_apps() -> Vec<DiscoveredApp> {
+    #[cfg(target_os = "windows")]
+    {
+        discover_windows_apps()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn discover_windows_apps() -> Vec<DiscoveredApp> {
+    use std::path::Path;
+
+    let mut apps = Vec::new();
+    let start_menu_paths = vec![
+        std::env::var("ProgramData")
+            .map(|p| Path::new(&p).join("Microsoft\\Windows\\Start Menu\\Programs"))
+            .ok(),
+        std::env::var("AppData")
+            .map(|p| Path::new(&p).join("Microsoft\\Windows\\Start Menu\\Programs"))
+            .ok(),
+    ];
+
+    for start_path in start_menu_paths.into_iter().flatten() {
+        if start_path.exists() {
+            discover_apps_in_dir(&start_path, &mut apps);
+        }
+    }
+
+    // Also check common installation directory
+    if let Ok(program_files) = std::env::var("ProgramFiles") {
+        let pf = Path::new(&program_files);
+        if pf.exists() {
+            discover_apps_in_dir(pf, &mut apps);
+        }
+    }
+    if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
+        let pf86 = Path::new(&program_files_x86);
+        if pf86.exists() {
+            discover_apps_in_dir(pf86, &mut apps);
+        }
+    }
+
+    // Sort by name and remove duplicates
+    apps.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    apps.dedup_by(|a, b| a.name.to_lowercase() == b.name.to_lowercase() && a.path == b.path);
+
+    eprintln!("[discover_apps] found {} applications", apps.len());
+    apps
+}
+
+#[cfg(target_os = "windows")]
+fn discover_apps_in_dir(dir: &std::path::Path, apps: &mut Vec<DiscoveredApp>) {
+    use std::fs;
+
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+
+            // Check if it's a shortcut (.lnk) file
+            if path.extension().map_or(false, |ext| ext == "lnk") {
+                if let Ok(target) = resolve_shortcut(&path) {
+                    if target.extension().map_or(false, |ext| ext == "exe") {
+                        let name = path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("Unknown")
+                            .to_string();
+                        let icon = extract_icon_from_exe(&target);
+                        apps.push(DiscoveredApp {
+                            name,
+                            path: target.to_string_lossy().to_string(),
+                            icon_base64: icon,
+                        });
+                    }
+                }
+            }
+            // Recurse into subdirectories
+            else if path.is_dir() {
+                discover_apps_in_dir(&path, apps);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_shortcut(lnk_path: &std::path::Path) -> Result<std::path::PathBuf, std::io::Error> {
+    use std::process::Command;
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "(New-Object -ComObject WScript.Shell).CreateShortcut('{}').TargetPath",
+                lnk_path.to_string_lossy().replace("'", "''")
+            ),
+        ])
+        .output()?;
+
+    if output.status.success() {
+        let target = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !target.is_empty() {
+            return Ok(std::path::PathBuf::from(target));
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "Could not resolve shortcut",
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn extract_icon_from_exe(exe_path: &std::path::Path) -> Option<String> {
+    use std::process::Command;
+
+    // Use PowerShell to extract icon
+    let ps_script = format!(
+        r#"[System.Drawing.Icon]::ExtractAssociatedIcon('{}').ToBitmap().Save([System.IO.MemoryStream]::new()); [Convert]::ToBase64String([System.IO.MemoryStream]::new().ToArray())""#,
+        exe_path.to_string_lossy().replace("'", "''")
+    );
+
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps_script])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let base64 = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !base64.is_empty() && base64.len() < 100_000 {
+            return Some(base64);
+        }
+    }
+    None
 }
 
 #[tauri::command]
@@ -548,6 +694,7 @@ pub fn run() {
             get_spaces,
             save_space,
             delete_space,
+            discover_apps,
             launch_space,
             get_monitors,
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,32 +322,39 @@ fn resolve_shortcut(lnk_path: &std::path::Path) -> Result<std::path::PathBuf, st
 fn extract_icon_from_exe(exe_path: &std::path::Path) -> Option<String> {
     use std::process::Command;
 
-    let exe_str = exe_path.to_string_lossy().replace("'", "''");
+    let exe_str = exe_path.to_string_lossy().replace('\'', "''");
     let ps_script = format!(
-        r#"
-$icon = [System.Drawing.Icon]::ExtractAssociatedIcon('{}')
-$bitmap = $icon.ToBitmap()
-$ms = [System.IO.MemoryStream]::new()
-$bitmap.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
-[Convert]::ToBase64String($ms.ToArray())
-"#,
+        r#"Add-Type -AssemblyName System.Drawing
+try {{
+  $icon = [System.Drawing.Icon]::ExtractAssociatedIcon('{0}')
+  if ($icon -eq $null) {{ exit 1 }}
+  $bitmap = $icon.ToBitmap()
+  $ms = New-Object System.IO.MemoryStream
+  $bitmap.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+  $bytes = $ms.ToArray()
+  $ms.Dispose()
+  $bitmap.Dispose()
+  $icon.Dispose()
+  [Convert]::ToBase64String($bytes)
+}} catch {{ exit 1 }}"#,
         exe_str
     );
 
     let output = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &ps_script])
+        .args(["-NoProfile", "-NonInteractive", "-Command", &ps_script])
         .output()
         .ok()?;
 
     if output.status.success() {
         let base64 = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !base64.is_empty() && base64.len() < 100_000 {
+        if base64.len() > 100 && base64.len() < 200_000 {
             return Some(base64);
         }
     }
     None
 }
 
+#[tauri::command]
 fn get_groups(state: State<SpacesState>) -> Vec<SpaceGroup> {
     state.groups.lock().unwrap().clone()
 }
@@ -817,6 +824,7 @@ fn launch_item_with_desktop(item: &SpaceItem, desktop_id: i64) -> Result<(), Str
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             let data_dir = app
                 .path()
@@ -839,9 +847,46 @@ pub fn run() {
             delete_group,
             launch_group,
             get_monitors,
+            get_config_dir,
+            set_config_dir,
+            pick_config_dir,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Config path – lets the user pick where spaces.json / groups.json are stored
+// ──────────────────────────────────────────────────────────────────────────────
+
+static CONFIG_DIR: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Returns the currently configured config directory path.
+#[tauri::command]
+fn get_config_dir() -> Option<String> {
+    CONFIG_DIR.lock().unwrap().clone()
+}
+
+/// Sets the config directory path.
+#[tauri::command]
+fn set_config_dir(path: Option<String>) -> Result<Option<String>, String> {
+    let mut guard = CONFIG_DIR.lock().map_err(|e| e.to_string())?;
+    *guard = path.clone();
+    Ok(path)
+}
+
+/// Picks a folder using the native OS dialog and returns the chosen path.
+#[tauri::command]
+fn pick_config_dir(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let (tx, rx) = std::sync::mpsc::channel::<Option<String>>();
+
+    app.dialog().file().pick_folder(move |folder| {
+        let _ = tx.send(folder.map(|f| f.to_string()));
+    });
+
+    rx.recv().map_err(|e| e.to_string())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { GroupForm } from "@/components/forms/GroupForm";
 import { GroupDetail } from "@/components/GroupDetail";
 import { ItemForm } from "@/components/forms/ItemForm";
 import { WindowPlacementDialog } from "@/components/WindowPlacementDialog";
+import { SettingsDialog } from "@/components/SettingsDialog";
 import { Layers } from "lucide-react";
 import type { Space, SpaceGroup, SpaceItem, WindowPlacement } from "@/types";
 
@@ -33,6 +34,9 @@ export default function App() {
   // Window placement dialog state
   const [placementDialogOpen, setPlacementDialogOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+
+  // Settings dialog state
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const loadSpaces = useCallback(async () => {
     try {
@@ -311,6 +315,7 @@ export default function App() {
           }}
           onNew={openNewSpace}
           onNewGroup={openNewGroup}
+          onOpenSettings={() => setSettingsOpen(true)}
         />
 
         <main className="flex-1 overflow-hidden">
@@ -384,6 +389,11 @@ export default function App() {
             setEditingItem(null);
           }}
           onSave={handleSaveItem}
+        />
+
+        <SettingsDialog
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
         />
       </div>
     </TooltipProvider>

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { invoke } from "@tauri-apps/api/core";
+import { SettingsDialog } from "./SettingsDialog";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("SettingsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  it("renders settings dialog when open", () => {
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText(/launch on startup/i)).toBeInTheDocument();
+    expect(screen.getByText(/minimize to tray/i)).toBeInTheDocument();
+    expect(screen.getByText(/default shell/i)).toBeInTheDocument();
+    expect(screen.getByText(/auto-save interval/i)).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<SettingsDialog open={false} onClose={vi.fn()} />);
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when Done is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<SettingsDialog open={true} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: /done/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when dialog is closed via overlay", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<SettingsDialog open={true} onClose={onClose} />);
+
+    // Click the overlay to close (DialogOverlay covers the screen)
+    const overlay = document.querySelector(
+      "[data-state='open']",
+    ) as HTMLElement;
+    if (overlay) {
+      // The overlay is behind the content; close via the X button or Escape
+      await user.keyboard("{Escape}");
+    }
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("toggles launch on startup setting", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const toggle = screen.getByRole("switch", { name: /launch on startup/i });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles minimize to tray setting", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const toggle = screen.getByRole("switch", { name: /minimize to tray/i });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("changes default shell", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const select = screen.getByRole("combobox", { name: /default shell/i });
+    expect(select).toHaveValue("powershell");
+
+    await user.selectOptions(select, "wt");
+    expect(select).toHaveValue("wt");
+  });
+
+  it("changes auto-save interval", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const select = screen.getByRole("combobox", {
+      name: /auto-save interval/i,
+    });
+    expect(select).toHaveValue("30");
+
+    await user.selectOptions(select, "60");
+    expect(select).toHaveValue("60");
+  });
+
+  it("resets settings to defaults", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    // Change a setting first
+    const toggle = screen.getByRole("switch", { name: /launch on startup/i });
+    await user.click(toggle);
+
+    // Reset
+    await user.click(
+      screen.getByRole("button", { name: /reset to defaults/i }),
+    );
+
+    // Toggle should be back to off
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    // appSearchPaths should be back to defaults
+    expect(screen.getByText("C:\\Program Files")).toBeInTheDocument();
+  });
+
+  it("renders default app search paths", () => {
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/app search directories/i)).toBeInTheDocument();
+    expect(screen.getByText("C:\\Program Files")).toBeInTheDocument();
+    expect(screen.getByText("C:\\Program Files (x86)")).toBeInTheDocument();
+  });
+
+  it("removes an app search path", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove directory/i,
+    });
+    // Remove "C:\\Program Files (x86)"
+    await user.click(removeButtons[1]);
+
+    expect(
+      screen.queryByText("C:\\Program Files (x86)"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("C:\\Program Files")).toBeInTheDocument();
+  });
+
+  it("adds a new app search path", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText("C:\\Program Files\\My App");
+    await user.type(input, "D:\\My Apps");
+
+    const addButton = screen.getByRole("button", { name: /add/i });
+    await user.click(addButton);
+
+    expect(screen.getByText("D:\\My Apps")).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("does not add duplicate app search paths", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    // Try to add an existing path
+    const input = screen.getByPlaceholderText("C:\\Program Files\\My App");
+    await user.type(input, "C:\\Program Files");
+
+    const addButton = screen.getByRole("button", { name: /add/i });
+    await user.click(addButton);
+
+    // Should still only have the original (no duplicate)
+    const pathTexts = screen.getAllByText("C:\\Program Files");
+    expect(pathTexts.length).toBe(1);
+  });
+
+  it("shows empty placeholder when all paths removed", async () => {
+    const user = userEvent.setup();
+    // Pre-clear storage and set empty paths
+    localStorage.setItem(
+      "spaces-app-settings",
+      JSON.stringify({ appSearchPaths: [] }),
+    );
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    // Remove remaining paths
+    const removeButtons = screen.queryAllByRole("button", {
+      name: /remove directory/i,
+    });
+    for (const btn of removeButtons) {
+      await user.click(btn);
+    }
+
+    // Should show the add input still
+    expect(
+      screen.getByPlaceholderText("C:\\Program Files\\My App"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders config path section", () => {
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/config save location/i)).toBeInTheDocument();
+    expect(screen.getByText("Default (AppData)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /browse/i })).toBeInTheDocument();
+  });
+
+  it("shows custom config path when set", () => {
+    localStorage.setItem(
+      "spaces-app-settings",
+      JSON.stringify({ configPath: "D:\\My Spaces" }),
+    );
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("D:\\My Spaces")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it("calls pick_config_dir when Browse is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(invoke).mockResolvedValue("E:\\Config");
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /browse/i }));
+    expect(invoke).toHaveBeenCalledWith("pick_config_dir");
+  });
+
+  it("clears config path when Clear is clicked", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      "spaces-app-settings",
+      JSON.stringify({ configPath: "D:\\My Spaces" }),
+    );
+    render(<SettingsDialog open={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+    expect(screen.getByText("Default (AppData)")).toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Settings, Plus, X, FolderOpen } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface AppSettings {
+  launchOnStartup: boolean;
+  minimizeToTray: boolean;
+  defaultShell: "powershell" | "cmd" | "wt";
+  autoSaveInterval: number; // seconds, 0 = disabled
+  appSearchPaths: string[];
+  configPath: string; // custom config directory path (empty = default)
+}
+
+const DEFAULT_SETTINGS: AppSettings = {
+  launchOnStartup: false,
+  minimizeToTray: false,
+  defaultShell: "powershell",
+  autoSaveInterval: 30,
+  appSearchPaths: [
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    "C:\\Users\\Default\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs",
+  ],
+  configPath: "",
+};
+
+const STORAGE_KEY = "spaces-app-settings";
+
+function loadSettings(): AppSettings {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_SETTINGS;
+}
+
+function saveSettings(settings: AppSettings) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // ignore
+  }
+}
+
+interface SettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+  const [settings, setSettings] = useState<AppSettings>(loadSettings);
+
+  useEffect(() => {
+    if (open) {
+      setSettings(loadSettings());
+    }
+  }, [open]);
+
+  function handleChange<K extends keyof AppSettings>(
+    key: K,
+    value: AppSettings[K],
+  ) {
+    setSettings((prev) => {
+      const next = { ...prev, [key]: value };
+      saveSettings(next);
+      return next;
+    });
+  }
+
+  function handleReset() {
+    const defaults = DEFAULT_SETTINGS;
+    saveSettings(defaults);
+    setSettings(defaults);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="w-[75vw] flex flex-col"
+        style={{ maxWidth: "75vw" }}
+      >
+        <div className="flex flex-col max-h-[85vh]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Settings className="h-5 w-5" />
+              Settings
+            </DialogTitle>
+            <DialogDescription>
+              Configure how Spaces behaves on your system.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex-1 overflow-y-auto space-y-5 py-4">
+            {/* Launch on startup */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="launch-startup" className="text-sm font-medium">
+                  Launch on startup
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Start Spaces when you log in to Windows.
+                </p>
+              </div>
+              <Toggle
+                id="launch-startup"
+                checked={settings.launchOnStartup}
+                onCheckedChange={(v) => handleChange("launchOnStartup", v)}
+              />
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Minimize to tray */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="minimize-tray" className="text-sm font-medium">
+                  Minimize to tray
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Keep Spaces running in the system tray when closed.
+                </p>
+              </div>
+              <Toggle
+                id="minimize-tray"
+                checked={settings.minimizeToTray}
+                onCheckedChange={(v) => handleChange("minimizeToTray", v)}
+              />
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Default shell */}
+            <div className="space-y-1.5">
+              <Label htmlFor="default-shell" className="text-sm font-medium">
+                Default shell
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Shell used when adding new terminal items.
+              </p>
+              <select
+                id="default-shell"
+                className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+                value={settings.defaultShell}
+                onChange={(e) =>
+                  handleChange(
+                    "defaultShell",
+                    e.target.value as AppSettings["defaultShell"],
+                  )
+                }
+              >
+                <option value="powershell">PowerShell</option>
+                <option value="cmd">Command Prompt (cmd)</option>
+                <option value="wt">Windows Terminal (wt)</option>
+              </select>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Auto-save interval */}
+            <div className="space-y-1.5">
+              <Label htmlFor="auto-save" className="text-sm font-medium">
+                Auto-save interval
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Periodically save spaces config. Set to 0 to disable.
+              </p>
+              <select
+                id="auto-save"
+                className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring"
+                value={settings.autoSaveInterval}
+                onChange={(e) =>
+                  handleChange("autoSaveInterval", Number(e.target.value))
+                }
+              >
+                <option value={0}>Disabled</option>
+                <option value={15}>15 seconds</option>
+                <option value={30}>30 seconds</option>
+                <option value={60}>1 minute</option>
+                <option value={300}>5 minutes</option>
+              </select>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* App search paths */}
+            <div className="space-y-2">
+              <div className="space-y-0.5">
+                <Label className="text-sm font-medium">
+                  App search directories
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Directories scanned when discovering apps. Remove built-in
+                  paths to hide them from search results.
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                {settings.appSearchPaths.map((path, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 truncate text-sm">{path}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0"
+                      onClick={() => {
+                        const next = settings.appSearchPaths.filter(
+                          (_, i) => i !== index,
+                        );
+                        handleChange("appSearchPaths", next);
+                      }}
+                      title="Remove directory"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+
+              <AddPathInput
+                paths={settings.appSearchPaths}
+                onAdd={(path) =>
+                  handleChange("appSearchPaths", [
+                    ...settings.appSearchPaths,
+                    path,
+                  ])
+                }
+              />
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Config path */}
+            <div className="space-y-2">
+              <div className="space-y-0.5">
+                <Label className="text-sm font-medium">
+                  Config save location
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Directory where spaces.json and groups.json are saved. Leave
+                  empty to use the default AppData location.
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="flex-1 truncate rounded-md border border-input bg-background px-3 py-1.5 text-sm text-muted-foreground">
+                  {settings.configPath || "Default (AppData)"}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 shrink-0"
+                  onClick={async () => {
+                    try {
+                      const path = await invoke<string | null>(
+                        "pick_config_dir",
+                      );
+                      if (path) {
+                        handleChange("configPath", path);
+                      }
+                    } catch (e) {
+                      console.error("Failed to pick folder:", e);
+                    }
+                  }}
+                >
+                  <FolderOpen className="h-4 w-4" />
+                  Browse
+                </Button>
+                {settings.configPath && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 shrink-0"
+                    onClick={() => handleChange("configPath", "")}
+                  >
+                    <X className="h-4 w-4" />
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0 pt-4 shrink-0">
+            <Button variant="outline" onClick={handleReset}>
+              Reset to defaults
+            </Button>
+            <Button onClick={onClose}>Done</Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Toggle({
+  id,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <button
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-input",
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+          checked ? "translate-x-4" : "translate-x-0",
+        )}
+      />
+    </button>
+  );
+}
+
+function AddPathInput({
+  paths,
+  onAdd,
+}: {
+  paths: string[];
+  onAdd: (path: string) => void;
+}) {
+  const [value, setValue] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    // Only add if not already in the list
+    if (!paths.includes(trimmed)) {
+      onAdd(trimmed);
+    }
+    setValue("");
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <Input
+        placeholder="C:\Program Files\My App"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="flex-1"
+      />
+      <Button
+        type="submit"
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        disabled={!value.trim()}
+      >
+        <Plus className="h-4 w-4" />
+        Add
+      </Button>
+    </form>
+  );
+}
+
+export function getSettings(): AppSettings {
+  return loadSettings();
+}

--- a/src/components/SpacesSidebar.test.tsx
+++ b/src/components/SpacesSidebar.test.tsx
@@ -36,6 +36,7 @@ const defaultProps = {
   onSelectGroup: vi.fn(),
   onNew: vi.fn(),
   onNewGroup: vi.fn(),
+  onOpenSettings: vi.fn(),
 };
 
 describe("SpacesSidebar", () => {

--- a/src/components/SpacesSidebar.tsx
+++ b/src/components/SpacesSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Play,
   Pencil,
   Trash2,
+  Settings,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -23,6 +24,7 @@ interface SpacesSidebarProps {
   onSelectGroup: (id: string) => void;
   onNew: () => void;
   onNewGroup: () => void;
+  onOpenSettings: () => void;
 }
 
 const COLOR_MAP: Record<string, string> = {
@@ -45,6 +47,7 @@ export function SpacesSidebar({
   onSelectGroup,
   onNew,
   onNewGroup,
+  onOpenSettings,
 }: SpacesSidebarProps) {
   const sorted = [...spaces].sort((a, b) => {
     if (a.isFavourite === b.isFavourite) return 0;
@@ -165,6 +168,15 @@ export function SpacesSidebar({
         >
           <Plus className="h-4 w-4" />
           Space
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={onOpenSettings}
+          title="Settings"
+        >
+          <Settings className="h-4 w-4" />
         </Button>
       </div>
 

--- a/src/components/WindowPlacementDialog.tsx
+++ b/src/components/WindowPlacementDialog.tsx
@@ -539,337 +539,354 @@ export function WindowPlacementDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col"
-      style={{ background: "hsl(224 40% 5%)" }}
+      className="fixed inset-0 z-50 flex flex-col items-center"
+      style={{ background: "rgba(0,0,0,0.65)", backdropFilter: "blur(4px)" }}
     >
-      {/* ── Header ─────────────────────────────────────────────────────── */}
       <div
-        className="flex shrink-0 items-center justify-between px-6"
+        className="flex flex-col overflow-hidden"
         style={{
-          height: 56,
-          borderBottom: "1px solid rgba(255,255,255,.07)",
-          background: "rgba(255,255,255,.02)",
+          width: "90vw",
+          height: "85vh",
+          background: "hsl(224 40% 5%)",
+          borderRadius: 14,
+          border: "1px solid rgba(255,255,255,.1)",
+          boxShadow: "0 24px 80px rgba(0,0,0,.8)",
         }}
       >
-        <div className="flex items-center gap-3">
-          <div
-            className="flex h-8 w-8 items-center justify-center rounded-lg"
-            style={{
-              background: "rgba(59,130,246,.2)",
-              border: "1px solid rgba(59,130,246,.3)",
-            }}
+        {/* ── Header (fixed) ─────────────────────────────────────────────── */}
+        <div
+          className="flex shrink-0 items-center justify-between px-6"
+          style={{
+            height: 56,
+            borderBottom: "1px solid rgba(255,255,255,.07)",
+            background: "rgba(255,255,255,.02)",
+          }}
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className="flex h-8 w-8 items-center justify-center rounded-lg"
+              style={{
+                background: "rgba(59,130,246,.2)",
+                border: "1px solid rgba(59,130,246,.3)",
+              }}
+            >
+              <MonitorIcon className="h-4 w-4 text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-white/90">
+                Place Windows
+              </h2>
+              <p className="text-[11px] text-white/35">
+                Drag onto monitors · edges to snap · corners to resize
+              </p>
+            </div>
+          </div>
+
+          {snapZone && (
+            <div
+              className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium text-blue-300"
+              style={{
+                background: "rgba(59,130,246,.18)",
+                border: "1px solid rgba(59,130,246,.4)",
+              }}
+            >
+              ⬡ {SNAP_LABELS[snapZone.zone.id]}
+            </div>
+          )}
+
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-white/40 transition-colors hover:bg-white/10 hover:text-white/70"
           >
-            <MonitorIcon className="h-4 w-4 text-blue-400" />
-          </div>
-          <div>
-            <h2 className="text-sm font-semibold text-white/90">
-              Place Windows
-            </h2>
-            <p className="text-[11px] text-white/35">
-              Drag onto monitors · edges to snap · corners to resize
-            </p>
-          </div>
+            <X className="h-4 w-4" />
+          </button>
         </div>
 
-        {snapZone && (
-          <div
-            className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium text-blue-300"
-            style={{
-              background: "rgba(59,130,246,.18)",
-              border: "1px solid rgba(59,130,246,.4)",
-            }}
-          >
-            ⬡ {SNAP_LABELS[snapZone.zone.id]}
-          </div>
-        )}
-
-        <button
-          onClick={onClose}
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-white/40 transition-colors hover:bg-white/10 hover:text-white/70"
+        {/* ── Canvas ─────────────────────────────────────────────────────── */}
+        <div
+          ref={canvasRef}
+          className="relative overflow-y-auto"
+          style={{
+            flex: 1,
+            cursor: busy ? "crosshair" : "default",
+          }}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
         >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
+          {monitors.length === 0 ? (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-white/20">No monitors detected</p>
+            </div>
+          ) : (
+            <>
+              {/* Monitor backgrounds */}
+              {monitorRects.map((mr) => {
+                const sz =
+                  snapZone?.monitorIndex === mr.monitor.index
+                    ? snapZone.zone
+                    : null;
+                const titleH = Math.max(10, mr.height * 0.055);
+                const dotR = Math.max(3, mr.height * 0.022);
 
-      {/* ── Canvas ─────────────────────────────────────────────────────── */}
-      <div
-        ref={canvasRef}
-        className="relative flex-1 overflow-hidden"
-        style={{ cursor: busy ? "crosshair" : "default" }}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-      >
-        {monitors.length === 0 ? (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-white/20">No monitors detected</p>
-          </div>
-        ) : (
-          <>
-            {/* Monitor backgrounds */}
-            {monitorRects.map((mr) => {
-              const sz =
-                snapZone?.monitorIndex === mr.monitor.index
-                  ? snapZone.zone
-                  : null;
-              const titleH = Math.max(10, mr.height * 0.055);
-              const dotR = Math.max(3, mr.height * 0.022);
-
-              return (
-                <div
-                  key={mr.monitor.index}
-                  className="absolute overflow-hidden"
-                  style={{
-                    left: mr.left,
-                    top: mr.top,
-                    width: mr.width,
-                    height: mr.height,
-                    borderRadius: 10,
-                    background:
-                      "linear-gradient(155deg, hsl(224 40% 12%) 0%, hsl(224 40% 9%) 100%)",
-                    border: "1.5px solid rgba(255,255,255,.1)",
-                    boxShadow:
-                      "0 8px 40px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.05)",
-                  }}
-                >
-                  {/* Dot-grid texture */}
+                return (
                   <div
-                    className="pointer-events-none absolute inset-0"
+                    key={mr.monitor.index}
+                    className="absolute overflow-hidden"
                     style={{
-                      backgroundImage:
-                        "radial-gradient(circle, rgba(255,255,255,.045) 1px, transparent 1px)",
-                      backgroundSize: "18px 18px",
-                    }}
-                  />
-
-                  {/* macOS-style title bar */}
-                  <div
-                    className="absolute left-0 right-0 top-0 flex items-center gap-1.5 px-2.5"
-                    style={{
-                      height: titleH,
-                      background: "rgba(255,255,255,.04)",
-                      borderBottom: "1px solid rgba(255,255,255,.05)",
+                      left: mr.left,
+                      top: mr.top,
+                      width: mr.width,
+                      height: mr.height,
+                      borderRadius: 10,
+                      background:
+                        "linear-gradient(155deg, hsl(224 40% 12%) 0%, hsl(224 40% 9%) 100%)",
+                      border: "1.5px solid rgba(255,255,255,.1)",
+                      boxShadow:
+                        "0 8px 40px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.05)",
                     }}
                   >
-                    {(["#EF4444", "#F59E0B", "#22C55E"] as const).map((c) => (
-                      <div
-                        key={c}
-                        style={{
-                          width: dotR * 2,
-                          height: dotR * 2,
-                          borderRadius: "50%",
-                          background: c,
-                          opacity: 0.65,
-                        }}
-                      />
-                    ))}
-                  </div>
-
-                  {/* Bottom label */}
-                  <div
-                    className="absolute bottom-1.5 left-2 font-medium"
-                    style={{
-                      fontSize: Math.max(8, mr.height * 0.038),
-                      color: "rgba(255,255,255,.18)",
-                    }}
-                  >
-                    {mr.monitor.name} · {mr.monitor.width}×{mr.monitor.height}
-                  </div>
-
-                  {/* Monitor index */}
-                  <div
-                    className="absolute right-2 flex items-center justify-center rounded-full font-bold"
-                    style={{
-                      top: titleH + 4,
-                      width: Math.max(14, mr.height * 0.065),
-                      height: Math.max(14, mr.height * 0.065),
-                      fontSize: Math.max(8, mr.height * 0.036),
-                      background: "rgba(255,255,255,.07)",
-                      color: "rgba(255,255,255,.3)",
-                    }}
-                  >
-                    {mr.monitor.index + 1}
-                  </div>
-
-                  {/* Snap zone overlay */}
-                  {sz && (
+                    {/* Dot-grid texture */}
                     <div
-                      className="pointer-events-none absolute"
+                      className="pointer-events-none absolute inset-0"
                       style={{
-                        left: `${sz.x * 100}%`,
-                        top: `${sz.y * 100}%`,
-                        width: `${sz.w * 100}%`,
-                        height: `${sz.h * 100}%`,
-                        background: "rgba(59,130,246,.2)",
-                        border: "2px solid rgba(59,130,246,.7)",
-                        borderRadius: 7,
-                        transition: "all .1s ease",
+                        backgroundImage:
+                          "radial-gradient(circle, rgba(255,255,255,.045) 1px, transparent 1px)",
+                        backgroundSize: "18px 18px",
                       }}
                     />
-                  )}
-                </div>
-              );
-            })}
 
-            {/* Placed chips */}
-            {items.map((item) => {
-              const pl = localPlacements[item.id];
-              if (!pl) return null;
-              const mr = monitorRects.find(
-                (r) => r.monitor.index === pl.monitorIndex,
-              );
-              if (!mr) return null;
-
-              const isActive = item.id === activeItemId;
-              const isDragging = drag?.itemId === item.id;
-              const c = isActive
-                ? CHIP_ACTIVE[item.type]
-                : CHIP_INACTIVE[item.type];
-
-              const chipLeft = mr.left + pl.x * mr.width;
-              const chipTop = mr.top + pl.y * mr.height;
-              const chipW = Math.max(pl.w * mr.width, 56);
-              const chipH = Math.max(pl.h * mr.height, 32);
-
-              return (
-                <div
-                  key={item.id}
-                  className="absolute select-none"
-                  style={{
-                    left: chipLeft,
-                    top: chipTop,
-                    width: chipW,
-                    height: chipH,
-                    background: c.bg,
-                    border: `1.5px solid ${c.border}`,
-                    borderRadius: 7,
-                    boxShadow: isDragging
-                      ? `0 20px 56px rgba(0,0,0,.8), 0 0 0 2px ${c.border}`
-                      : isActive
-                        ? `0 4px 20px ${c.shadow}, 0 0 0 1px ${c.border}`
-                        : "0 2px 8px rgba(0,0,0,.3)",
-                    cursor: isDragging ? "grabbing" : "grab",
-                    zIndex: isDragging ? 30 : isActive ? 15 : 10,
-                    transition:
-                      isDragging || resize?.itemId === item.id
-                        ? "none"
-                        : "box-shadow .15s",
-                  }}
-                  onPointerDown={(e) => startDrag(e, item)}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelectItem(isActive ? null : item.id);
-                  }}
-                >
-                  <div className="flex h-full items-center justify-center px-2">
-                    <span
-                      className="truncate font-medium"
+                    {/* macOS-style title bar */}
+                    <div
+                      className="absolute left-0 right-0 top-0 flex items-center gap-1.5 px-2.5"
                       style={{
-                        fontSize: Math.max(10, Math.min(13, chipH * 0.28)),
-                        color: c.text,
+                        height: titleH,
+                        background: "rgba(255,255,255,.04)",
+                        borderBottom: "1px solid rgba(255,255,255,.05)",
                       }}
                     >
-                      {item.name}
-                    </span>
-                  </div>
+                      {(["#EF4444", "#F59E0B", "#22C55E"] as const).map((c) => (
+                        <div
+                          key={c}
+                          style={{
+                            width: dotR * 2,
+                            height: dotR * 2,
+                            borderRadius: "50%",
+                            background: c,
+                            opacity: 0.65,
+                          }}
+                        />
+                      ))}
+                    </div>
 
-                  {/* Corner resize handles (active chip only) */}
-                  {isActive &&
-                    (["nw", "ne", "se", "sw"] as ResizeHandle[]).map((h) => (
+                    {/* Bottom label */}
+                    <div
+                      className="absolute bottom-1.5 left-2 font-medium"
+                      style={{
+                        fontSize: Math.max(8, mr.height * 0.038),
+                        color: "rgba(255,255,255,.18)",
+                      }}
+                    >
+                      {mr.monitor.name} · {mr.monitor.width}×{mr.monitor.height}
+                    </div>
+
+                    {/* Monitor index */}
+                    <div
+                      className="absolute right-2 flex items-center justify-center rounded-full font-bold"
+                      style={{
+                        top: titleH + 4,
+                        width: Math.max(14, mr.height * 0.065),
+                        height: Math.max(14, mr.height * 0.065),
+                        fontSize: Math.max(8, mr.height * 0.036),
+                        background: "rgba(255,255,255,.07)",
+                        color: "rgba(255,255,255,.3)",
+                      }}
+                    >
+                      {mr.monitor.index + 1}
+                    </div>
+
+                    {/* Snap zone overlay */}
+                    {sz && (
                       <div
-                        key={h}
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          startResize(e, item, h);
-                        }}
+                        className="pointer-events-none absolute"
                         style={{
-                          position: "absolute",
-                          width: 9,
-                          height: 9,
-                          background: "#fff",
-                          border: `2px solid ${c.border}`,
-                          borderRadius: 2,
-                          boxShadow: "0 1px 4px rgba(0,0,0,.5)",
-                          zIndex: 40,
-                          ...(h.includes("n") ? { top: -5 } : { bottom: -5 }),
-                          ...(h.includes("w") ? { left: -5 } : { right: -5 }),
-                          cursor:
-                            h === "nw" || h === "se"
-                              ? "nwse-resize"
-                              : "nesw-resize",
+                          left: `${sz.x * 100}%`,
+                          top: `${sz.y * 100}%`,
+                          width: `${sz.w * 100}%`,
+                          height: `${sz.h * 100}%`,
+                          background: "rgba(59,130,246,.2)",
+                          border: "2px solid rgba(59,130,246,.7)",
+                          borderRadius: 7,
+                          transition: "all .1s ease",
                         }}
                       />
-                    ))}
-                </div>
-              );
-            })}
+                    )}
+                  </div>
+                );
+              })}
 
-            {/* Unplaced tray */}
-            {unassigned.length > 0 && (
-              <div
-                className="absolute bottom-5 left-1/2"
-                style={{
-                  transform: "translateX(-50%)",
-                  background: "rgba(13,17,27,.92)",
-                  backdropFilter: "blur(20px)",
-                  border: "1px solid rgba(255,255,255,.1)",
-                  borderRadius: 14,
-                  padding: "10px 16px",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  boxShadow: "0 8px 32px rgba(0,0,0,.6)",
-                }}
-              >
-                <span
+              {/* Placed chips */}
+              {items.map((item) => {
+                const pl = localPlacements[item.id];
+                if (!pl) return null;
+                const mr = monitorRects.find(
+                  (r) => r.monitor.index === pl.monitorIndex,
+                );
+                if (!mr) return null;
+
+                const isActive = item.id === activeItemId;
+                const isDragging = drag?.itemId === item.id;
+                const c = isActive
+                  ? CHIP_ACTIVE[item.type]
+                  : CHIP_INACTIVE[item.type];
+
+                const chipLeft = mr.left + pl.x * mr.width;
+                const chipTop = mr.top + pl.y * mr.height;
+                const chipW = Math.max(pl.w * mr.width, 56);
+                const chipH = Math.max(pl.h * mr.height, 32);
+
+                return (
+                  <div
+                    key={item.id}
+                    className="absolute select-none"
+                    style={{
+                      left: chipLeft,
+                      top: chipTop,
+                      width: chipW,
+                      height: chipH,
+                      background: c.bg,
+                      border: `1.5px solid ${c.border}`,
+                      borderRadius: 7,
+                      boxShadow: isDragging
+                        ? `0 20px 56px rgba(0,0,0,.8), 0 0 0 2px ${c.border}`
+                        : isActive
+                          ? `0 4px 20px ${c.shadow}, 0 0 0 1px ${c.border}`
+                          : "0 2px 8px rgba(0,0,0,.3)",
+                      cursor: isDragging ? "grabbing" : "grab",
+                      zIndex: isDragging ? 30 : isActive ? 15 : 10,
+                      transition:
+                        isDragging || resize?.itemId === item.id
+                          ? "none"
+                          : "box-shadow .15s",
+                    }}
+                    onPointerDown={(e) => startDrag(e, item)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelectItem(isActive ? null : item.id);
+                    }}
+                  >
+                    <div className="flex h-full items-center justify-center px-2">
+                      <span
+                        className="truncate font-medium"
+                        style={{
+                          fontSize: Math.max(10, Math.min(13, chipH * 0.28)),
+                          color: c.text,
+                        }}
+                      >
+                        {item.name}
+                      </span>
+                    </div>
+
+                    {/* Corner resize handles (active chip only) */}
+                    {isActive &&
+                      (["nw", "ne", "se", "sw"] as ResizeHandle[]).map((h) => (
+                        <div
+                          key={h}
+                          onPointerDown={(e) => {
+                            e.stopPropagation();
+                            startResize(e, item, h);
+                          }}
+                          style={{
+                            position: "absolute",
+                            width: 9,
+                            height: 9,
+                            background: "#fff",
+                            border: `2px solid ${c.border}`,
+                            borderRadius: 2,
+                            boxShadow: "0 1px 4px rgba(0,0,0,.5)",
+                            zIndex: 40,
+                            ...(h.includes("n") ? { top: -5 } : { bottom: -5 }),
+                            ...(h.includes("w") ? { left: -5 } : { right: -5 }),
+                            cursor:
+                              h === "nw" || h === "se"
+                                ? "nwse-resize"
+                                : "nesw-resize",
+                          }}
+                        />
+                      ))}
+                  </div>
+                );
+              })}
+
+              {/* Unplaced tray */}
+              {unassigned.length > 0 && (
+                <div
+                  className="absolute bottom-5 left-1/2"
                   style={{
-                    fontSize: 10,
-                    fontWeight: 600,
-                    color: "rgba(255,255,255,.25)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.08em",
-                    marginRight: 4,
-                    whiteSpace: "nowrap",
+                    transform: "translateX(-50%)",
+                    background: "rgba(13,17,27,.92)",
+                    backdropFilter: "blur(20px)",
+                    border: "1px solid rgba(255,255,255,.1)",
+                    borderRadius: 14,
+                    padding: "10px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    boxShadow: "0 8px 32px rgba(0,0,0,.6)",
                   }}
                 >
-                  Unplaced
-                </span>
-                {unassigned.map((item) => {
-                  const isActive = item.id === activeItemId;
-                  const c = isActive
-                    ? CHIP_ACTIVE[item.type]
-                    : CHIP_INACTIVE[item.type];
-                  return (
-                    <div
-                      key={item.id}
-                      onPointerDown={(e) => startDrag(e, item)}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectItem(isActive ? null : item.id);
-                      }}
-                      style={{
-                        background: c.bg,
-                        border: `1.5px solid ${c.border}`,
-                        borderRadius: 7,
-                        padding: "6px 14px",
-                        cursor: "grab",
-                        fontSize: 12,
-                        fontWeight: 500,
-                        color: c.text,
-                        whiteSpace: "nowrap",
-                        userSelect: "none",
-                        boxShadow: isActive ? `0 0 0 2px ${c.border}` : "none",
-                        transition: "box-shadow .15s",
-                      }}
-                    >
-                      {item.name}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 600,
+                      color: "rgba(255,255,255,.25)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      marginRight: 4,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Unplaced
+                  </span>
+                  {unassigned.map((item) => {
+                    const isActive = item.id === activeItemId;
+                    const c = isActive
+                      ? CHIP_ACTIVE[item.type]
+                      : CHIP_INACTIVE[item.type];
+                    return (
+                      <div
+                        key={item.id}
+                        onPointerDown={(e) => startDrag(e, item)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSelectItem(isActive ? null : item.id);
+                        }}
+                        style={{
+                          background: c.bg,
+                          border: `1.5px solid ${c.border}`,
+                          borderRadius: 7,
+                          padding: "6px 14px",
+                          cursor: "grab",
+                          fontSize: 12,
+                          fontWeight: 500,
+                          color: c.text,
+                          whiteSpace: "nowrap",
+                          userSelect: "none",
+                          boxShadow: isActive
+                            ? `0 0 0 2px ${c.border}`
+                            : "none",
+                          transition: "box-shadow .15s",
+                        }}
+                      >
+                        {item.name}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/forms/ItemForm.tsx
+++ b/src/components/forms/ItemForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Plus, X } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { Plus, X, FolderSearch, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,7 +20,8 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import type { SpaceItem, SpaceItemType } from "@/types";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { SpaceItem, SpaceItemType, DiscoveredApp } from "@/types";
 
 interface ItemFormProps {
   open: boolean;
@@ -36,6 +38,12 @@ export function ItemForm({ open, initial, onClose, onSave }: ItemFormProps) {
   const [appPath, setAppPath] = useState("");
   const [appArgs, setAppArgs] = useState<string[]>([]);
   const [argInput, setArgInput] = useState("");
+
+  // app browser
+  const [showAppBrowser, setShowAppBrowser] = useState(false);
+  const [discoveredApps, setDiscoveredApps] = useState<DiscoveredApp[]>([]);
+  const [isLoadingApps, setIsLoadingApps] = useState(false);
+  const [appSearch, setAppSearch] = useState("");
 
   // terminal
   const [termCwd, setTermCwd] = useState("");
@@ -186,7 +194,34 @@ export function ItemForm({ open, initial, onClose, onSave }: ItemFormProps) {
           {type === "application" && (
             <>
               <div className="space-y-2">
-                <Label htmlFor="app-path">Executable Path</Label>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="app-path">Executable Path</Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 text-xs"
+                    onClick={async () => {
+                      setIsLoadingApps(true);
+                      try {
+                        const apps = await invoke<DiscoveredApp[]>("discover_apps");
+                        setDiscoveredApps(apps);
+                        setShowAppBrowser(true);
+                      } catch (e) {
+                        console.error("Failed to discover apps:", e);
+                      } finally {
+                        setIsLoadingApps(false);
+                      }
+                    }}
+                  >
+                    {isLoadingApps ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <FolderSearch className="h-3 w-3" />
+                    )}
+                    Browse
+                  </Button>
+                </div>
                 <Input
                   id="app-path"
                   placeholder="C:\Program Files\...\app.exe"
@@ -345,6 +380,66 @@ export function ItemForm({ open, initial, onClose, onSave }: ItemFormProps) {
                 />
               </div>
             </>
+          )}
+
+          {/* App browser dialog */}
+          {showAppBrowser && (
+            <div className="rounded-md border border-border">
+              <div className="flex items-center gap-2 border-b border-border p-3">
+                <Input
+                  placeholder="Search apps..."
+                  value={appSearch}
+                  onChange={(e) => setAppSearch(e.target.value)}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAppBrowser(false)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <ScrollArea className="h-64">
+                {discoveredApps.length === 0 ? (
+                  <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                    {isLoadingApps ? "Loading..." : "No apps found"}
+                  </div>
+                ) : (
+                  <div className="p-1">
+                    {discoveredApps
+                      .filter((app) =>
+                        app.name.toLowerCase().includes(appSearch.toLowerCase())
+                      )
+                      .slice(0, 50)
+                      .map((app) => (
+                        <button
+                          key={app.path}
+                          type="button"
+                          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm hover:bg-accent"
+                          onClick={() => {
+                            setAppPath(app.path);
+                            setName(app.name);
+                            setShowAppBrowser(false);
+                          }}
+                        >
+                          {app.iconBase64 ? (
+                            <img
+                              src={`data:image/png;base64,${app.iconBase64}`}
+                              alt={app.name}
+                              className="h-6 w-6 object-contain"
+                            />
+                          ) : (
+                            <div className="h-6 w-6 rounded bg-muted" />
+                          )}
+                          <span className="truncate">{app.name}</span>
+                        </button>
+                      ))}
+                  </div>
+                )}
+              </ScrollArea>
+            </div>
           )}
 
           <DialogFooter>

--- a/src/components/forms/ItemForm.tsx
+++ b/src/components/forms/ItemForm.tsx
@@ -148,301 +148,309 @@ export function ItemForm({ open, initial, onClose, onSave }: ItemFormProps) {
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
+      <DialogContent
+        className="flex flex-col"
+        style={{ maxWidth: "75vw", maxHeight: "85vh" }}
+      >
+        <DialogHeader className="shrink-0">
           <DialogTitle>{initial ? "Edit Item" : "Add Item"}</DialogTitle>
           <DialogDescription>
             Configure what to launch when this space is activated.
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Type selector */}
-          <div className="space-y-2">
-            <Label>Type</Label>
-            <Select
-              value={type}
-              onValueChange={(v) => setType(v as SpaceItemType)}
-              disabled={!!initial}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="application">Application</SelectItem>
-                <SelectItem value="terminal">Terminal</SelectItem>
-                <SelectItem value="url">URL</SelectItem>
-                <SelectItem value="script">Script</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
+          <div className="flex-1 overflow-y-auto space-y-4 pr-1">
+            {/* Type selector */}
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={type}
+                onValueChange={(v) => setType(v as SpaceItemType)}
+                disabled={!!initial}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="application">Application</SelectItem>
+                  <SelectItem value="terminal">Terminal</SelectItem>
+                  <SelectItem value="url">URL</SelectItem>
+                  <SelectItem value="script">Script</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
 
-          {/* Name */}
-          <div className="space-y-2">
-            <Label htmlFor="item-name">Name</Label>
-            <Input
-              id="item-name"
-              placeholder="e.g. VS Code"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              autoFocus
-            />
-          </div>
+            {/* Name */}
+            <div className="space-y-2">
+              <Label htmlFor="item-name">Name</Label>
+              <Input
+                id="item-name"
+                placeholder="e.g. VS Code"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
 
-          {/* --- Application fields --- */}
-          {type === "application" && (
-            <>
+            {/* --- Application fields --- */}
+            {type === "application" && (
+              <>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="app-path">Executable Path</Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 gap-1 text-xs"
+                      onClick={async () => {
+                        setIsLoadingApps(true);
+                        try {
+                          const apps =
+                            await invoke<DiscoveredApp[]>("discover_apps");
+                          setDiscoveredApps(apps);
+                          setShowAppBrowser(true);
+                        } catch (e) {
+                          console.error("Failed to discover apps:", e);
+                        } finally {
+                          setIsLoadingApps(false);
+                        }
+                      }}
+                    >
+                      {isLoadingApps ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <FolderSearch className="h-3 w-3" />
+                      )}
+                      Browse
+                    </Button>
+                  </div>
+                  <Input
+                    id="app-path"
+                    placeholder="C:\Program Files\...\app.exe"
+                    value={appPath}
+                    onChange={(e) => setAppPath(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Arguments</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Add argument…"
+                      value={argInput}
+                      onChange={(e) => setArgInput(e.target.value)}
+                      onKeyDown={(e) =>
+                        e.key === "Enter" && (e.preventDefault(), addArg())
+                      }
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={addArg}
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  {appArgs.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {appArgs.map((arg, i) => (
+                        <span
+                          key={i}
+                          className="flex items-center gap-1 rounded bg-secondary px-2 py-0.5 text-xs"
+                        >
+                          {arg}
+                          <button
+                            type="button"
+                            onClick={() => removeArg(i)}
+                            aria-label="Remove"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
+            {/* --- Terminal fields --- */}
+            {type === "terminal" && (
+              <>
+                <div className="space-y-2">
+                  <Label>Shell</Label>
+                  <Select
+                    value={termShell}
+                    onValueChange={(v) =>
+                      setTermShell(v as "wt" | "powershell" | "cmd")
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="wt">Windows Terminal</SelectItem>
+                      <SelectItem value="powershell">PowerShell</SelectItem>
+                      <SelectItem value="cmd">Command Prompt</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="term-cwd">Working Directory</Label>
+                  <Input
+                    id="term-cwd"
+                    placeholder="C:\Users\you\project"
+                    value={termCwd}
+                    onChange={(e) => setTermCwd(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="term-cmds">
+                    Commands{" "}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      (one per line)
+                    </span>
+                  </Label>
+                  <Textarea
+                    id="term-cmds"
+                    rows={4}
+                    placeholder={"npm run dev\ngit status"}
+                    value={termCommands}
+                    onChange={(e) => setTermCommands(e.target.value)}
+                    className="font-mono text-xs"
+                  />
+                </div>
+              </>
+            )}
+
+            {/* --- URL fields --- */}
+            {type === "url" && (
               <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="app-path">Executable Path</Label>
+                <Label htmlFor="url-value">URL</Label>
+                <Input
+                  id="url-value"
+                  type="url"
+                  placeholder="https://example.com"
+                  value={urlValue}
+                  onChange={(e) => setUrlValue(e.target.value)}
+                />
+              </div>
+            )}
+
+            {/* --- Script fields --- */}
+            {type === "script" && (
+              <>
+                <div className="space-y-2">
+                  <Label>Shell</Label>
+                  <Select
+                    value={scriptShell}
+                    onValueChange={(v) =>
+                      setScriptShell(v as "powershell" | "cmd")
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="powershell">PowerShell</SelectItem>
+                      <SelectItem value="cmd">Command Prompt</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="script-cwd">Working Directory</Label>
+                  <Input
+                    id="script-cwd"
+                    placeholder="C:\Users\you\project"
+                    value={scriptCwd}
+                    onChange={(e) => setScriptCwd(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="script-content">Script Content</Label>
+                  <Textarea
+                    id="script-content"
+                    rows={6}
+                    placeholder={
+                      scriptShell === "powershell"
+                        ? "Write-Host 'Hello'\n# your script here"
+                        : "@echo off\necho Hello"
+                    }
+                    value={scriptContent}
+                    onChange={(e) => setScriptContent(e.target.value)}
+                    className="font-mono text-xs"
+                  />
+                </div>
+              </>
+            )}
+
+            {/* App browser dialog */}
+            {showAppBrowser && (
+              <div className="rounded-md border border-border">
+                <div className="flex items-center gap-2 border-b border-border p-3">
+                  <Input
+                    placeholder="Search apps..."
+                    value={appSearch}
+                    onChange={(e) => setAppSearch(e.target.value)}
+                    className="flex-1"
+                  />
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="h-7 gap-1 text-xs"
-                    onClick={async () => {
-                      setIsLoadingApps(true);
-                      try {
-                        const apps = await invoke<DiscoveredApp[]>("discover_apps");
-                        setDiscoveredApps(apps);
-                        setShowAppBrowser(true);
-                      } catch (e) {
-                        console.error("Failed to discover apps:", e);
-                      } finally {
-                        setIsLoadingApps(false);
-                      }
-                    }}
+                    onClick={() => setShowAppBrowser(false)}
                   >
-                    {isLoadingApps ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <FolderSearch className="h-3 w-3" />
-                    )}
-                    Browse
+                    <X className="h-4 w-4" />
                   </Button>
                 </div>
-                <Input
-                  id="app-path"
-                  placeholder="C:\Program Files\...\app.exe"
-                  value={appPath}
-                  onChange={(e) => setAppPath(e.target.value)}
-                />
+                <ScrollArea className="h-64">
+                  {discoveredApps.length === 0 ? (
+                    <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                      {isLoadingApps ? "Loading..." : "No apps found"}
+                    </div>
+                  ) : (
+                    <div className="p-1">
+                      {discoveredApps
+                        .filter((app) =>
+                          app.name
+                            .toLowerCase()
+                            .includes(appSearch.toLowerCase()),
+                        )
+                        .slice(0, 50)
+                        .map((app) => (
+                          <button
+                            key={app.path}
+                            type="button"
+                            className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm hover:bg-accent"
+                            onClick={() => {
+                              setAppPath(app.path);
+                              setName(app.name);
+                              setShowAppBrowser(false);
+                            }}
+                          >
+                            {app.iconBase64 ? (
+                              <img
+                                src={`data:image/png;base64,${app.iconBase64}`}
+                                alt={app.name}
+                                className="h-6 w-6 object-contain"
+                              />
+                            ) : (
+                              <div className="h-6 w-6 rounded bg-muted" />
+                            )}
+                            <span className="truncate">{app.name}</span>
+                          </button>
+                        ))}
+                    </div>
+                  )}
+                </ScrollArea>
               </div>
-              <div className="space-y-2">
-                <Label>Arguments</Label>
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Add argument…"
-                    value={argInput}
-                    onChange={(e) => setArgInput(e.target.value)}
-                    onKeyDown={(e) =>
-                      e.key === "Enter" && (e.preventDefault(), addArg())
-                    }
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={addArg}
-                  >
-                    <Plus className="h-4 w-4" />
-                  </Button>
-                </div>
-                {appArgs.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5">
-                    {appArgs.map((arg, i) => (
-                      <span
-                        key={i}
-                        className="flex items-center gap-1 rounded bg-secondary px-2 py-0.5 text-xs"
-                      >
-                        {arg}
-                        <button
-                          type="button"
-                          onClick={() => removeArg(i)}
-                          aria-label="Remove"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </>
-          )}
+            )}
+          </div>
 
-          {/* --- Terminal fields --- */}
-          {type === "terminal" && (
-            <>
-              <div className="space-y-2">
-                <Label>Shell</Label>
-                <Select
-                  value={termShell}
-                  onValueChange={(v) =>
-                    setTermShell(v as "wt" | "powershell" | "cmd")
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="wt">Windows Terminal</SelectItem>
-                    <SelectItem value="powershell">PowerShell</SelectItem>
-                    <SelectItem value="cmd">Command Prompt</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="term-cwd">Working Directory</Label>
-                <Input
-                  id="term-cwd"
-                  placeholder="C:\Users\you\project"
-                  value={termCwd}
-                  onChange={(e) => setTermCwd(e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="term-cmds">
-                  Commands{" "}
-                  <span className="text-xs font-normal text-muted-foreground">
-                    (one per line)
-                  </span>
-                </Label>
-                <Textarea
-                  id="term-cmds"
-                  rows={4}
-                  placeholder={"npm run dev\ngit status"}
-                  value={termCommands}
-                  onChange={(e) => setTermCommands(e.target.value)}
-                  className="font-mono text-xs"
-                />
-              </div>
-            </>
-          )}
-
-          {/* --- URL fields --- */}
-          {type === "url" && (
-            <div className="space-y-2">
-              <Label htmlFor="url-value">URL</Label>
-              <Input
-                id="url-value"
-                type="url"
-                placeholder="https://example.com"
-                value={urlValue}
-                onChange={(e) => setUrlValue(e.target.value)}
-              />
-            </div>
-          )}
-
-          {/* --- Script fields --- */}
-          {type === "script" && (
-            <>
-              <div className="space-y-2">
-                <Label>Shell</Label>
-                <Select
-                  value={scriptShell}
-                  onValueChange={(v) =>
-                    setScriptShell(v as "powershell" | "cmd")
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="powershell">PowerShell</SelectItem>
-                    <SelectItem value="cmd">Command Prompt</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="script-cwd">Working Directory</Label>
-                <Input
-                  id="script-cwd"
-                  placeholder="C:\Users\you\project"
-                  value={scriptCwd}
-                  onChange={(e) => setScriptCwd(e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="script-content">Script Content</Label>
-                <Textarea
-                  id="script-content"
-                  rows={6}
-                  placeholder={
-                    scriptShell === "powershell"
-                      ? "Write-Host 'Hello'\n# your script here"
-                      : "@echo off\necho Hello"
-                  }
-                  value={scriptContent}
-                  onChange={(e) => setScriptContent(e.target.value)}
-                  className="font-mono text-xs"
-                />
-              </div>
-            </>
-          )}
-
-          {/* App browser dialog */}
-          {showAppBrowser && (
-            <div className="rounded-md border border-border">
-              <div className="flex items-center gap-2 border-b border-border p-3">
-                <Input
-                  placeholder="Search apps..."
-                  value={appSearch}
-                  onChange={(e) => setAppSearch(e.target.value)}
-                  className="flex-1"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setShowAppBrowser(false)}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-              <ScrollArea className="h-64">
-                {discoveredApps.length === 0 ? (
-                  <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-                    {isLoadingApps ? "Loading..." : "No apps found"}
-                  </div>
-                ) : (
-                  <div className="p-1">
-                    {discoveredApps
-                      .filter((app) =>
-                        app.name.toLowerCase().includes(appSearch.toLowerCase())
-                      )
-                      .slice(0, 50)
-                      .map((app) => (
-                        <button
-                          key={app.path}
-                          type="button"
-                          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm hover:bg-accent"
-                          onClick={() => {
-                            setAppPath(app.path);
-                            setName(app.name);
-                            setShowAppBrowser(false);
-                          }}
-                        >
-                          {app.iconBase64 ? (
-                            <img
-                              src={`data:image/png;base64,${app.iconBase64}`}
-                              alt={app.name}
-                              className="h-6 w-6 object-contain"
-                            />
-                          ) : (
-                            <div className="h-6 w-6 rounded bg-muted" />
-                          )}
-                          <span className="truncate">{app.name}</span>
-                        </button>
-                      ))}
-                  </div>
-                )}
-              </ScrollArea>
-            </div>
-          )}
-
-          <DialogFooter>
+          <DialogFooter className="shrink-0 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -32,3 +32,22 @@ body {
   color: var(--color-foreground);
   font-feature-settings: "rlig" 1, "calt" 1;
 }
+
+/* Custom scrollbar - dark theme */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-background);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-muted-foreground);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(240 5% 74.9%);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,3 +101,10 @@ export const SPACE_COLORS = [
   { value: "cyan", label: "Cyan", class: "bg-cyan-500" },
   { value: "yellow", label: "Yellow", class: "bg-yellow-500" },
 ] as const;
+
+// Discovered app from Windows
+export interface DiscoveredApp {
+  name: string;
+  path: string;
+  iconBase64?: string;
+}


### PR DESCRIPTION
## Summary

This PR implements **two major features**: an app discovery browser with icons for the "Add Item" dialog, and a comprehensive settings dialog — along with numerous UI refinements to the window placement dialog and form layouts.

---

## Features

### 1. App Discovery with Icons (`discover_apps`)

**Backend (Rust):**
- New `discover_apps` Tauri command scans predefined Windows directories (`Program Files`, `Program Files (x86)`, Start Menu) for `.exe` files
- Extracts application icons using `System.Drawing.Icon.ExtractAssociatedIcon` via PowerShell, converts them to PNG base64
- Returns `DiscoveredApp[]` with `name`, `path`, and `iconBase64`
- Recursively scans directories up to 5 levels deep, deduplicates by path, returns max 500 apps

**Frontend (`ItemForm`):**
- "Browse" button triggers `invoke("discover_apps")` and shows a searchable app browser panel inside the form
- Apps are displayed in a scrollable list with their extracted icons (`data:image/png;base64,...`)
- Clicking an app auto-fills the `path` and `name` fields and closes the browser
- Search filters the list by app name (case-insensitive, shows top 50 results)

### 2. Settings Dialog

**New `SettingsDialog` component** with localStorage persistence under key `"spaces-app-settings"`:

| Setting | Description |
|---|---|
| Launch on startup | Toggle (persisted, UI wired) |
| Minimize to tray | Toggle (persisted, UI wired) |
| Default shell | Select: Windows Terminal / PowerShell / Command Prompt |
| Auto-save interval | Select: Off / 15s / 30s / 60s |
| App search directories | List of paths to scan for `discover_apps`; supports add/remove with duplicate prevention |
| Config save location | Custom YAML config directory via native OS folder picker (`tauri-plugin-dialog`) |

**Settings UI features:**
- Opens via gear icon in the `SpacesSidebar` footer
- 75vw wide modal with scrollable body and fixed footer
- "Reset to defaults" button restores all defaults
- "Done" button saves and closes

**Backend (Rust):**
- Added `tauri-plugin-dialog = "2"` dependency and capability
- New Tauri commands: `get_config_dir`, `set_config_dir`, `pick_config_dir`
- `pick_config_dir` uses `DialogExt::pick_folder` for native OS folder selection

### 3. Window Placement Dialog Improvements

**Layout:**
- Converted from fullscreen `fixed inset-0` overlay to a centered modal (70vw → 90vw wide, 85vh tall)
- Semi-transparent blurred backdrop (`backdrop-filter: blur(4px)`)
- Fixed header + scrollable canvas body — no longer overflows when many items are placed

**Fixed bugs:**
- Dialog no longer clips vertically at smaller window sizes
- Canvas body scrolls when content exceeds available height

### 4. ItemForm Layout Improvements

**Fixed overflow when app browser is open:**
- Changed from `sm:max-w-lg` (512px) to `75vw` wide modal
- Capped at `85vh` with scrollable form body (`overflow-y-auto`)
- Fixed footer (Cancel/Add buttons stay pinned at bottom)
- Restructured using `flex flex-col` with `shrink-0` header/footer and `flex-1 min-h-0` scrollable content area

---

## Files Changed

| File | Change |
|---|---|
| `src-tauri/Cargo.toml` | Added `tauri-plugin-dialog = "2"` |
| `src-tauri/capabilities/default.json` | Added `dialog:default` permission |
| `src-tauri/src/lib.rs` | `discover_apps` command, icon extraction via PowerShell, `pick_config_dir`, `get_config_dir`, `set_config_dir` |
| `src/components/SettingsDialog.tsx` | New settings dialog with 6 settings sections |
| `src/components/SettingsDialog.test.tsx` | 18 tests for settings dialog |
| `src/components/SpacesSidebar.tsx` | Added gear icon button, `onOpenSettings` prop |
| `src/components/SpacesSidebar.test.tsx` | Updated for `onOpenSettings` |
| `src/components/WindowPlacementDialog.tsx` | Converted to centered modal, scrollable body |
| `src/components/forms/ItemForm.tsx` | App browser with icons, scrollable layout |
| `src/App.tsx` | `SettingsDialog` wired up, `onOpenSettings` handler |
| `src/index.css` | Custom scrollbar styling |
| `src/types.ts` | `DiscoveredApp` type, `AppSettings` interface |

---

## Testing

All **92 tests pass** across 9 test files.